### PR TITLE
Fix: remove deprecated beforeToolCall and onError from McpServer config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,52 +15,6 @@ import { getRoutesTool } from './tools/flights/getRoutes.js';
 const server = new McpServer({
   name: 'seats-mcp',
   version: '1.0.1',
-  beforeToolCall: async (toolName: string) => {
-    return {
-      messages: [
-        {
-          role: 'assistant',
-          content: {
-            type: 'text',
-            text: `This server provides tools to search for award flight availability through seats.aero.
-                Available tools:
-                1. Get Flights: Search for specific flight routes between airports
-                  - Requires origin and destination airports
-                  - Optional filters for dates, cabin class, and carriers
-                  - Returns detailed flight information including pricing
-
-                2. Get Bulk Availability: Search for bulk availability across regions
-                  - Requires a specific airline source
-                  - Optional filters for cabin class, dates, and regions
-                  - Returns available award seats for the specified airline
-
-                3. Get Routes: Search for routes for a particular source
-                  - Requires a specific airline source
-
-                Note: All operations require a valid SEATS_API_KEY environment variable.
-                At no points should you ever search the web, you should only use the tools provided.
-
-                Cabin classes available: economy, premium, business, first
-                Date format required: YYYY-MM-DD
-                sources supported: eurobonus, virginatlantic, aeromexico, american, delta, etihad, united, emirates, aeroplan, alaska, velocity, qantas, and more.`,
-          },
-        },
-      ],
-    };
-  },
-  onError: async (error: Error) => {
-    return {
-      messages: [
-        {
-          role: 'assistant',
-          content: {
-            type: 'text',
-            text: `An error occurred: ${error.message}\n\nPlease ensure:\n- SEATS_API_KEY is properly set\n- Input parameters are correctly formatted\n- The requested airline source is supported`,
-          },
-        },
-      ],
-    };
-  },
 });
 
 server.tool(

--- a/src/tools/flights/getBulkAvail.ts
+++ b/src/tools/flights/getBulkAvail.ts
@@ -19,6 +19,7 @@ const getBulkAvailTool = async (params: GetBulkAvailParams) => {
 
     if (!process.env.SEATS_API_KEY) {
       return {
+        isError: true,
         content: [
           {
             type: 'text' as const,
@@ -53,6 +54,7 @@ const getBulkAvailTool = async (params: GetBulkAvailParams) => {
     if (!bulkAvail.ok) {
       const errorText = await bulkAvail.text().catch(() => 'Unknown error');
       return {
+        isError: true,
         content: [
           {
             type: 'text' as const,
@@ -89,6 +91,7 @@ const getBulkAvailTool = async (params: GetBulkAvailParams) => {
     };
   } catch (error) {
     return {
+      isError: true,
       content: [
         {
           type: 'text' as const,

--- a/src/tools/flights/getFlights.ts
+++ b/src/tools/flights/getFlights.ts
@@ -22,6 +22,7 @@ export async function getFlightsTool(args: GetFlightsParams) {
 
     if (!process.env.SEATS_API_KEY) {
       return {
+        isError: true,
         content: [
           {
             type: 'text' as const,
@@ -58,6 +59,7 @@ export async function getFlightsTool(args: GetFlightsParams) {
     if (!flights.ok) {
       const errorText = await flights.text().catch(() => 'Unknown error');
       return {
+        isError: true,
         content: [
           {
             type: 'text' as const,
@@ -90,6 +92,7 @@ export async function getFlightsTool(args: GetFlightsParams) {
     };
   } catch (error) {
     return {
+      isError: true,
       content: [
         {
           type: 'text' as const,

--- a/src/tools/flights/getRoutes.ts
+++ b/src/tools/flights/getRoutes.ts
@@ -9,6 +9,7 @@ export async function getRoutesTool(args: GetRoutesParams) {
 
     if (!process.env.SEATS_API_KEY) {
       return {
+        isError: true,
         content: [
           {
             type: 'text' as const,
@@ -34,6 +35,7 @@ export async function getRoutesTool(args: GetRoutesParams) {
     if (!routes.ok) {
       const errorText = await routes.text().catch(() => 'Unknown error');
       return {
+        isError: true,
         content: [
           {
             type: 'text' as const,
@@ -66,6 +68,7 @@ export async function getRoutesTool(args: GetRoutesParams) {
     };
   } catch (error) {
     return {
+      isError: true,
       content: [
         {
           type: 'text' as const,


### PR DESCRIPTION
These options were removed in @modelcontextprotocol/sdk v1.x and cause a TypeScript compilation error with current SDK versions.